### PR TITLE
Fix links, especially user login and registration

### DIFF
--- a/Pokefans/App_Start/Startup.Auth.cs
+++ b/Pokefans/App_Start/Startup.Auth.cs
@@ -1,18 +1,16 @@
 ﻿// Copyright 2015 the pokefans-core authors. See copying.md for legal info.
+
 using System;
+using System.Configuration;
+using System.Web.Mvc;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Owin;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.Google;
 using Owin;
-using Pokefans.Models;
 using Pokefans.Data;
-using System.Threading.Tasks;
-using System.Security.Claims;
 using Pokefans.Security;
-using System.Web.Mvc;
-using System.Configuration;
 
 namespace Pokefans
 {
@@ -21,7 +19,7 @@ namespace Pokefans
         // Weitere Informationen zum Konfigurieren der Authentifizierung finden Sie unter "http://go.microsoft.com/fwlink/?LinkId=301864".
         public void ConfigureAuth(IAppBuilder app)
         {
-            app.CreatePerOwinContext<ApplicationUserManager>(() => DependencyResolver.Current.GetService<ApplicationUserManager>());
+            app.CreatePerOwinContext(() => DependencyResolver.Current.GetService<ApplicationUserManager>());
 
             // Anwendung für die Verwendung eines Cookies zum Speichern von Informationen für den angemeldeten Benutzer aktivieren
             // und ein Cookie zum vorübergehenden Speichern von Informationen zu einem Benutzer zu verwenden, der sich mit dem Anmeldeanbieter eines Drittanbieters anmeldet.
@@ -29,10 +27,10 @@ namespace Pokefans
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
-                LoginPath = new PathString("/Account/Login"),
+                LoginPath = new PathString("/anmeldung"),
                 Provider = new CookieAuthenticationProvider
                 {
-                    OnApplyRedirect = ApplyRedirect, 
+                    OnApplyRedirect = ApplyRedirect,
                     // Aktiviert die Anwendung für die Überprüfung des Sicherheitsstempels, wenn sich der Benutzer anmeldet.
                     // Dies ist eine Sicherheitsfunktion, die verwendet wird, wenn Sie ein Kennwort ändern oder Ihrem Konto eine externe Anmeldung hinzufügen.  
                     OnValidateIdentity = SecurityStampValidator.OnValidateIdentity<ApplicationUserManager, User, int>(
@@ -42,7 +40,7 @@ namespace Pokefans
                 },
                 CookieDomain = ConfigurationManager.AppSettings["CookieDomain"],
                 CookieName = ConfigurationManager.AppSettings["CookieName"]
-            });            
+            });
             app.UseExternalSignInCookie(DefaultAuthenticationTypes.ExternalCookie);
 
             // Aktiviert die Anwendung für das vorübergehende Speichern von Benutzerinformationen beim Überprüfen der zweiten Stufe im zweistufigen Authentifizierungsvorgang.
@@ -77,7 +75,7 @@ namespace Pokefans
 
             if (bool.Parse(ConfigurationManager.AppSettings["UseGoogleAuthentication"]))
             {
-                app.UseGoogleAuthentication(new GoogleOAuth2AuthenticationOptions()
+                app.UseGoogleAuthentication(new GoogleOAuth2AuthenticationOptions
                 {
                     ClientId = ConfigurationManager.AppSettings["GoogleAuthenticationClientId"],
                     ClientSecret = ConfigurationManager.AppSettings["GoogleAuthenticationClientSecret"]
@@ -97,10 +95,11 @@ namespace Pokefans
                         context.RedirectUri = "https://";
                     else
                         context.RedirectUri = "http://";
-                    context.RedirectUri += "user." + ConfigurationManager.AppSettings["Domain"] + "/Account/Login";
+                    context.RedirectUri += "user." + ConfigurationManager.AppSettings["Domain"] + ":" +
+                                           ConfigurationManager.AppSettings["port"] + "/anmeldung";
                     context.RedirectUri += new QueryString(
-                            context.Options.ReturnUrlParameter,
-                            context.Request.Uri.AbsoluteUri).ToString();
+                        context.Options.ReturnUrlParameter,
+                        context.Request.Uri.AbsoluteUri).ToString();
                 }
             }
 

--- a/Pokefans/Views/Shared/_LoginPartial.cshtml
+++ b/Pokefans/Views/Shared/_LoginPartial.cshtml
@@ -1,17 +1,16 @@
 ﻿@using Microsoft.AspNet.Identity
-@using System.Configuration;
 @if (Request.IsAuthenticated)
 {
-    using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new { id = "logoutForm", @class = "navbar-right" }))
+    using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new {id = "logoutForm", @class = "navbar-right"}))
     {
-    @Html.AntiForgeryToken()
+        @Html.AntiForgeryToken()
 
-            @Html.ActionLink("Hallo " + User.Identity.GetUserName() + "!", "Index", "Manage", routeValues: null, htmlAttributes: new { title = "Manage" })
+        @Html.ActionLink("Hallo " + User.Identity.GetUserName() + "!", "Index", "Manage", null, new {title = "Manage"})
         <a href="javascript:document.getElementById('logoutForm').submit()">Abmelden</a>
     }
 }
 else
 {
-        @Html.ActionLink("Registrieren", "Register", "Account", "user", routeValues: null, htmlAttributes: new { id = "registerLink" })<span> | </span>
-        @Html.ActionLink("Anmelden", "Login", "Account", "user", routeValues: null, htmlAttributes: new { id = "loginLink" })
+    @Html.ActionLink("Registrieren", "Register", "Account", "user", new {area = "user"}, new {id = "registerLink"})<span> | </span>
+    @Html.ActionLink("Anmelden", "Login", "Account", "user", new { area = "user" }, new {id = "loginLink"})
 }

--- a/Pokefans/Web.config
+++ b/Pokefans/Web.config
@@ -23,7 +23,8 @@
         <add key="FromEmailName" value="Pokefans.NET" />
         <add key="VariableLessPath" value="G:\Projekte\Pokefans\pokeboot\less\variables.less" />
         <add key="ContentStylesheetPath" value="/var/www/pokefans/static/stylesheets/content/" />
-        <add key="Domain" value="pokefans.localhost" />
+        <add key="Domain" value="pokefans.rocks" />
+      <add key="Port" value="50000" />
         <add key="PreferedProtocol" value="http" />
         <!-- pun intended -->
         <!-- Main Page Options -->

--- a/Util/LinkExtensions.cs
+++ b/Util/LinkExtensions.cs
@@ -24,7 +24,8 @@ namespace Pokefans.Util
         /// <returns></returns>
         public static MvcHtmlString ResourceLink(this HtmlHelper helper, string path)
         {
-            return new MvcHtmlString(String.Format("//{0}/{1}", ConfigurationManager.AppSettings["Domain"], path));
+            var port = ConfigurationManager.AppSettings["Port"];
+            return new MvcHtmlString($"//{ConfigurationManager.AppSettings["Domain"]}:{port}/{path}");
         }
 
         /// <summary>
@@ -36,7 +37,8 @@ namespace Pokefans.Util
         /// <returns></returns>
         public static MvcHtmlString ResourceLink(this HtmlHelper helper, string path, string domain)
         {
-            return new MvcHtmlString(String.Format("//{2}.{0}/{1}", ConfigurationManager.AppSettings["Domain"], path, domain));
+            var port = ConfigurationManager.AppSettings["Port"];
+            return new MvcHtmlString($"//{domain}.{ConfigurationManager.AppSettings["Domain"]}:{port}/{path}");
         }
 
         public static MvcHtmlString ActionLink(this HtmlHelper htmlHelper, string linkText, string actionName, bool requireAbsoluteUrl)


### PR DESCRIPTION
This commit includes changes that fix the resolution of the login and registration controller actions. The commit also adds support for custom ports for absolute urls. Previously, the urls would default to port 80.

The PR contains some formatting (IDE defaults), so there more changes than necessary.

Please review whether this actually works (especially for port 80, I can't start the server on port 80), I'm not sure that everything is set up correctly on my machine.
